### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ BoC needs some documentation, but contains lots of usefull stuff like
 * Logging wrapper (see BoC.Logging.log4net for implementation)
 * Persistence repository and service pattern implementation (see other BoC packages like BoC.Persistence.NHibernate for implementations)
 
-#BoC and Sitecore
+# BoC and Sitecore
 If you would like to get started with the BoC and Sitecore, follow this excellent tutorial by Guido van Tricht:
 http://guidovtricht.nl/2015/07/sitecore-mvc-musicstore-part-1/


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
